### PR TITLE
Add options for Courier authlib authentication to user_sql.php

### DIFF
--- a/lib/user_sql.php
+++ b/lib/user_sql.php
@@ -354,6 +354,22 @@ class OC_USER_SQL extends BackendUtility implements \OCP\IUserBackend,
         {
                     $enc_password = $this->pw_hash($password);
         }
+        elseif($this -> settings['set_crypt_type'] === 'courier_md5')
+        {
+            $enc_password = '{MD5}'.OC_USER_SQL::hex_to_base64(md5($password));
+        }
+        elseif($this -> settings['set_crypt_type'] === 'courier_md5raw')
+        {
+            $enc_password = '{MD5RAW}'.md5($password);
+        }
+        elseif($this -> settings['set_crypt_type'] === 'courier_sha1')
+        {
+            $enc_password = '{SHA}'.OC_USER_SQL::hex_to_base64(sha1($password));
+        }
+        elseif($this -> settings['set_crypt_type'] === 'courier_sha256')
+        {
+            $enc_password = '{SHA256}'.OC_USER_SQL::hex_to_base64(hash('sha256', $password, false));
+        }
          else
         {
             $enc_password = $this -> pacrypt($password, $old_password);
@@ -422,10 +438,26 @@ class OC_USER_SQL extends BackendUtility implements \OCP\IUserBackend,
                 return false;
             $ret = sha1($salt['salt'].sha1($password)) === $db_pass;
         }
-        
+
         elseif($this -> settings['set_crypt_type'] == 'sha1')
         {
             $ret = $this->hash_equals(sha1($password) , $db_pass);
+        }
+        elseif($this -> settings['set_crypt_type'] === 'courier_md5')
+        {
+            $ret = '{MD5}'.OC_USER_SQL::hex_to_base64(md5($password)) === $db_pass;
+        }
+        elseif($this -> settings['set_crypt_type'] === 'courier_md5raw')
+        {
+            $ret = '{MD5RAW}'.md5($password) === $db_pass;
+        }
+        elseif($this -> settings['set_crypt_type'] === 'courier_sha1')
+        {
+            $ret = '{SHA}'.OC_USER_SQL::hex_to_base64(sha1($password)) === $db_pass;
+        }
+        elseif($this -> settings['set_crypt_type'] === 'courier_sha256')
+        {
+            $ret = '{SHA256}'.OC_USER_SQL::hex_to_base64(hash('sha256', $password, false)) === $db_pass;
         } else
 
         {
@@ -974,7 +1006,16 @@ class OC_USER_SQL extends BackendUtility implements \OCP\IUserBackend,
         }
 
         return $result === 0;
-}
+    }
+
+    private static function hex_to_base64($hex)
+    {
+        $hex_chr = '';
+        foreach(str_split($hex, 2) as $hexpair)
+        {
+            $hex_chr .= chr(hexdec($hexpair));
+        }
+        return base64_encode($hex_chr);
+    }
 
 }
-

--- a/templates/admin.php
+++ b/templates/admin.php
@@ -70,7 +70,7 @@ $cfgClass =  'section';
             <p><label for="col_displayname"><?php p($l -> t('Real Name Column')); ?></label><input type="text" id="col_displayname" name="col_displayname" value="<?php p($_['col_displayname']); ?>" /></p>
 
             <p><label for="set_crypt_type"><?php p($l -> t('Encryption Type')); ?></label>
-                <?php $crypt_types = array('md5' => 'MD5', 'md5crypt' => 'MD5 Crypt', 'cleartext' => 'Cleartext', 'mysql_encrypt' => 'mySQL ENCRYPT()', 'system' => 'System (crypt)', 'password_hash' => 'password_hash','mysql_password' => 'mySQL PASSWORD()', 'joomla' => 'Joomla MD5 Encryption', 'joomla2' => 'Joomla > 2.5.18 phpass', 'ssha256' => 'Salted SSHA256', 'redmine' => 'Redmine', 'sha1' => 'SHA1'); ?>
+                <?php $crypt_types = array('md5' => 'MD5', 'md5crypt' => 'MD5 Crypt', 'cleartext' => 'Cleartext', 'mysql_encrypt' => 'mySQL ENCRYPT()', 'system' => 'System (crypt)', 'password_hash' => 'password_hash','mysql_password' => 'mySQL PASSWORD()', 'joomla' => 'Joomla MD5 Encryption', 'joomla2' => 'Joomla > 2.5.18 phpass', 'ssha256' => 'Salted SSHA256', 'redmine' => 'Redmine', 'sha1' => 'SHA1', 'courier_md5' => 'Courier base64-encoded MD5', 'courier_md5raw' => 'Courier hexadecimal MD5', 'courier_sha1' => 'Courier base64-encoded SHA1', 'courier_sha256' => 'Courier base64-encoded SHA256'); ?>
                 <select id="set_crypt_type" name="set_crypt_type">
                     <?php
                         foreach ($crypt_types as $driver => $name):


### PR DESCRIPTION
Availible options:
courier_md5 – base64-encoded md5
courier_md5raw – hexadecimal md5
courier_sha1 – base64-encoded sha1
courier_sha256 – base64-encoded sha256