### PR TITLE
Include user display name and email in user searches

### DIFF
--- a/lib/Query/QueryProvider.php
+++ b/lib/Query/QueryProvider.php
@@ -163,6 +163,8 @@ class QueryProvider implements \ArrayAccess
                 "SELECT $userColumns " .
                 "FROM $user u " .
                 "WHERE u.$uUID LIKE :$searchParam " .
+                "OR u.$uName LIKE :$searchParam " .
+                "OR u.$uEmail LIKE :$searchParam " .
                 "ORDER BY u.$uUID",
 
             Query::UPDATE_DISPLAY_NAME =>


### PR DESCRIPTION
Extend user search to respect display name and email. Related issue: #91 

Is it OK to simply include email in the search or should there be some kind of configuration option/switch?