### PR TITLE
getUsers result type in UserBackend

### DIFF
--- a/lib/Backend/UserBackend.php
+++ b/lib/Backend/UserBackend.php
@@ -446,13 +446,13 @@ final class UserBackend extends ABackend implements
             $this->cache->set("user_" . $user->uid, $user);
         }
 
-        $usersCache = array_map(
+        $users = array_map(
             function ($user) {
                 return $user->uid;
             }, $users
         );
 
-        $this->cache->set($cacheKey, $usersCache);
+        $this->cache->set($cacheKey, $users);
         $this->logger->debug(
             "Returning getUsers($search, $limit, $offset): count(" . count(
                 $users


### PR DESCRIPTION
`getUsers` should return array of users, currently returns ['uid'], as per https://docs.nextcloud.com/server/16/developer_manual/api/OC/User/Backend.html#OC\User\Backend::getDisplayNames

This allows nextcloud to correctly perform autocompletion when searching a user, for example when sharing a directory.