### PR TITLE
Fix #120 and #126 Closure to string conversion

### DIFF
--- a/lib/Backend/UserBackend.php
+++ b/lib/Backend/UserBackend.php
@@ -469,12 +469,12 @@ final class UserBackend extends ABackend implements
             $this->cache->set("user_" . $user->uid, $user);
         }
 
-        $callback = is_callable($callback)
+        $user_callback = is_callable($callback)
             ? $callback
             : function ($user) {
                 return $user->uid;
             };
-        $users = array_map($callback, $users);
+        $users = array_map($user_callback, $users);
 
         $this->cache->set($cacheKey, $users);
         $this->logger->debug(


### PR DESCRIPTION
I got the same error as in #120 and #126 

At some point `getUsers` gets called with `$callback` being `null`. Then `is_callable` fails, and `$callback` gets set to the closure `function($user) { return $user->uid; };`. On line 481, `$callback` is converted to string for the purpose of writing a debug log line. That's not allowed.

One workaround is to just rename the variable such that if `$callback` is `null`, `null` gets converted to string and not the closure.