### PR TITLE
Use new dispatcher for password policy event

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,7 +22,7 @@
     <category>auth</category>
     <dependencies>
         <php min-version="7.1"/>
-        <nextcloud min-version="14" max-version="19"/>
+        <nextcloud min-version="18" max-version="19"/>
     </dependencies>
     <settings>
         <admin>\OCA\UserSQL\Settings\Admin</admin>


### PR DESCRIPTION
Followup to https://github.com/nextcloud/server/pull/18019 and allows to drop the old ones in the password policy app. It works from 18 onwards thus I raised the version in the info.xml. Currently the oldest supported version is 17.