### PR TITLE
Use new dispatcher for password policy event

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,7 +22,7 @@
     <category>auth</category>
     <dependencies>
         <php min-version="7.1"/>
-        <nextcloud min-version="14" max-version="19"/>
+        <nextcloud min-version="18" max-version="19"/>
     </dependencies>
     <settings>
         <admin>\OCA\UserSQL\Settings\Admin</admin>

--- a/lib/Backend/UserBackend.php
+++ b/lib/Backend/UserBackend.php
@@ -104,13 +104,13 @@ final class UserBackend extends ABackend implements
     /**
      * The default constructor.
      *
-     * @param string          $AppName         The application name.
-     * @param Cache           $cache           The cache instance.
-     * @param ILogger         $logger          The logger instance.
-     * @param Properties      $properties      The properties array.
-     * @param UserRepository  $userRepository  The user repository.
-     * @param IL10N           $localization    The localization service.
-     * @param IConfig         $config          The config instance.
+     * @param string           $AppName         The application name.
+     * @param Cache            $cache           The cache instance.
+     * @param ILogger          $logger          The logger instance.
+     * @param Properties       $properties      The properties array.
+     * @param UserRepository   $userRepository  The user repository.
+     * @param IL10N            $localization    The localization service.
+     * @param IConfig          $config          The config instance.
      * @param IEventDispatcher $eventDispatcher The event dispatcher.
      */
     public function __construct(


### PR DESCRIPTION
Followup to nextcloud/server#18019 and allows to drop the old ones in the password policy app. It works from 18 onwards thus I raised the version in the info.xml. Currently the oldest supported version is 17.

That would help us move forward the password policy app. We would like to remove that with one of the coming Nextcloud releases (best would be 20). 