### PR TITLE
Selecting and counting users from the User-Group table needs DISTINCT…

### DIFF
--- a/lib/Query/QueryProvider.php
+++ b/lib/Query/QueryProvider.php
@@ -135,7 +135,7 @@ class QueryProvider implements \ArrayAccess
                 "AND g.$gAdmin",
 
             Query::COUNT_GROUPS =>
-                "SELECT COUNT(ug.$ugGID) " .
+                "SELECT COUNT(DISTINCT ug.$ugUID) " .
                 "FROM $userGroup ug " .
                 "WHERE ug.$ugGID LIKE :$gidParam " .
                 "AND ug.$ugUID LIKE :$searchParam",
@@ -152,7 +152,7 @@ class QueryProvider implements \ArrayAccess
                 "WHERE g.$gGID = :$gidParam",
 
             Query::FIND_GROUP_USERS =>
-                "SELECT ug.$ugUID AS uid " .
+                "SELECT DISTINCT ug.$ugUID AS uid " .
                 "FROM $userGroup ug " .
                 "WHERE ug.$ugGID LIKE :$gidParam " .
                 "AND ug.$ugUID LIKE :$searchParam " .


### PR DESCRIPTION
… to avoid duplicates.

In particular when using the catch-all group ("Default Group" setting)
the queries which count and select users from the User-Group table need
the "DISTINCT" option: the catch-all group is replaced by a '%'
wild-card in the query. As users may belong by design to more than one
group counting and selecting users comes out wrong. Even worse: the many
duplicates interfere with the paging logic of the user admin-settings.

Signed-off-by: Claus-Justus Heine <himself@claus-justus-heine.de>