### PR TITLE
Production/cafevdb/stable27

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,7 +22,7 @@
     <category>auth</category>
     <dependencies>
         <php min-version="7.1"/>
-        <nextcloud min-version="21" max-version="23"/>
+        <nextcloud min-version="21" max-version="24"/>
     </dependencies>
     <settings>
         <admin>\OCA\UserSQL\Settings\Admin</admin>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,7 +22,7 @@
     <category>auth</category>
     <dependencies>
         <php min-version="7.1"/>
-        <nextcloud min-version="21" max-version="24"/>
+        <nextcloud min-version="21" max-version="25"/>
     </dependencies>
     <settings>
         <admin>\OCA\UserSQL\Settings\Admin</admin>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -21,8 +21,8 @@
     </types>
     <category>auth</category>
     <dependencies>
-        <php min-version="7.1"/>
-        <nextcloud min-version="21" max-version="27"/>
+        <php min-version="8.0"/>
+        <nextcloud min-version="25" max-version="27"/>
     </dependencies>
     <settings>
         <admin>\OCA\UserSQL\Settings\Admin</admin>

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -22,7 +22,7 @@
     <category>auth</category>
     <dependencies>
         <php min-version="7.1"/>
-        <nextcloud min-version="21" max-version="25"/>
+        <nextcloud min-version="21" max-version="27"/>
     </dependencies>
     <settings>
         <admin>\OCA\UserSQL\Settings\Admin</admin>

--- a/lib/Backend/UserBackend.php
+++ b/lib/Backend/UserBackend.php
@@ -459,6 +459,18 @@ final class UserBackend extends ABackend implements
                 "Returning from cache getUsers($search, $limit, $offset): count("
                 . count($users) . ")", ["app" => $this->appName]
             );
+            // convert to user-model
+            foreach ($users as $index => $cachedUser) {
+              if (!is_array($cachedUser)) {
+                break;
+              }
+              $user = new User();
+              foreach ($cachedUser as $key => $value) {
+                $user->{$key} = $value;
+              }
+              $users[$index] = $user;
+            }
+
             return $users;
         }
 

--- a/lib/Constant/Query.php
+++ b/lib/Constant/Query.php
@@ -32,6 +32,7 @@ final class Query
     const COUNT_GROUPS = "count_groups";
     const COUNT_USERS = "count_users";
     const FIND_GROUP = "find_group";
+    const FIND_GROUP_UIDS = "find_group_uids";
     const FIND_GROUP_USERS = "find_group_users";
     const FIND_GROUPS = "find_groups";
     const FIND_USER_BY_UID = "find_user_by_uid";

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -92,6 +92,8 @@ class SettingsController extends Controller
      * Verify the database connection parameters.
      *
      * @return array The request status.
+     *
+     * @AuthorizedAdminSetting(settings=OCA\UserSQL\Settings\Admin)
      */
     public function verifyDbConnection()
     {
@@ -189,6 +191,8 @@ class SettingsController extends Controller
      * Save application properties.
      *
      * @return array The request status.
+     *
+     * @AuthorizedAdminSetting(settings=OCA\UserSQL\Settings\Admin)
      */
     public function saveProperties()
     {
@@ -329,6 +333,8 @@ class SettingsController extends Controller
      * Clear the application cache memory.
      *
      * @return array The request status.
+     *
+     * @AuthorizedAdminSetting(settings=OCA\UserSQL\Settings\Admin)
      */
     public function clearCache()
     {
@@ -356,6 +362,8 @@ class SettingsController extends Controller
      * Autocomplete for table select options.
      *
      * @return array The database table list.
+     *
+     * @AuthorizedAdminSetting(settings=OCA\UserSQL\Settings\Admin)
      */
     public function tableAutocomplete()
     {
@@ -385,6 +393,8 @@ class SettingsController extends Controller
      * Autocomplete for column select options - user table.
      *
      * @return array The database table's column list.
+     *
+     * @AuthorizedAdminSetting(settings=OCA\UserSQL\Settings\Admin)
      */
     public function userTableAutocomplete()
     {
@@ -430,6 +440,8 @@ class SettingsController extends Controller
      * Autocomplete for column select options - user_group table.
      *
      * @return array The database table's column list.
+     *
+     * @AuthorizedAdminSetting(settings=OCA\UserSQL\Settings\Admin)
      */
     public function userGroupTableAutocomplete()
     {
@@ -451,6 +463,8 @@ class SettingsController extends Controller
      * Autocomplete for column select options - group table.
      *
      * @return array The database table's column list.
+     *
+     * @AuthorizedAdminSetting(settings=OCA\UserSQL\Settings\Admin)
      */
     public function groupTableAutocomplete()
     {
@@ -473,6 +487,8 @@ class SettingsController extends Controller
      *
      * @return array Password algorithm parameters.
      * @throws ReflectionException Whenever Opt class cannot be initiated.
+     *
+     * @AuthorizedAdminSetting(settings=OCA\UserSQL\Settings\Admin)
      */
     public function cryptoParams()
     {

--- a/lib/Properties.php
+++ b/lib/Properties.php
@@ -203,7 +203,7 @@ class Properties implements \ArrayAccess
     /**
      * @inheritdoc
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset):bool
     {
         return isset($this->data[$offset]);
     }
@@ -211,7 +211,7 @@ class Properties implements \ArrayAccess
     /**
      * @inheritdoc
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset):mixed
     {
         if (isset($this->data[$offset])) {
             return $this->data[$offset];
@@ -223,7 +223,7 @@ class Properties implements \ArrayAccess
     /**
      * @inheritdoc
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value):void
     {
         if ($offset == Opt::SAFE_STORE) {
             $this->safeStore = ($value === App::TRUE_VALUE);
@@ -255,7 +255,7 @@ class Properties implements \ArrayAccess
     /**
      * @inheritdoc
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset):void
     {
         if ($offset == Opt::SAFE_STORE) {
             $this->safeStore = App::FALSE_VALUE;

--- a/lib/Query/DataQuery.php
+++ b/lib/Query/DataQuery.php
@@ -109,7 +109,15 @@ class DataQuery
         }
 
         $query = $this->queryProvider[$queryName];
-        $result = $this->connection->prepare($query, $limit, $offset);
+        try {
+            $result = $this->connection->prepare($query, $limit, $offset);
+        } catch (DBALException  $exception) {
+            $this->logger->error(
+                "Could not prepare the query: " . $exception->getMessage(),
+                ["app" => $this->appName]
+            );
+            return false;
+        }
 
         foreach ($params as $param => $value) {
             $result->bindValue(":" . $param, $value);

--- a/lib/Query/DataQuery.php
+++ b/lib/Query/DataQuery.php
@@ -224,6 +224,27 @@ class DataQuery
     }
 
     /**
+     * Fetch values from all columns which the given query returns.
+     *
+     * @param string $queryName The query to execute.
+     * @param array  $params    The query parameters to bind.
+     * @param int    $limit     Results limit. Defaults to -1 (no limit).
+     * @param int    $offset    Results offset. Defaults to 0.
+     *
+     * @return array|bool Queried column or FALSE on failure.
+     */
+    public function queryColumns(
+        $queryName, $params = [], $limit = -1, $offset = 0
+    ) {
+        $result = $this->execQuery($queryName, $params, $limit, $offset);
+        if ($result === false) {
+            return false;
+        }
+
+        return $result->fetchAll();
+    }
+
+    /**
      * Fetch entity returned by the given query.
      *
      * @param string $queryName   The query to execute.

--- a/lib/Query/DataQuery.php
+++ b/lib/Query/DataQuery.php
@@ -109,13 +109,13 @@ class DataQuery
         }
 
         $query = $this->queryProvider[$queryName];
+
         try {
             $result = $this->connection->prepare($query, $limit, $offset);
         } catch (DBALException  $exception) {
-            $this->logger->error(
-                "Could not prepare the query: " . $exception->getMessage(),
-                ["app" => $this->appName]
-            );
+            $this->logger->logException(
+				$exception, [ 'message' => "Could not prepare the query: " . $query ]
+			);
             return false;
         }
 
@@ -123,20 +123,16 @@ class DataQuery
             $result->bindValue(":" . $param, $value);
         }
 
-        $this->logger->debug(
-            "Executing query: " . $query . ", " . implode(",", $params),
-            ["app" => $this->appName]
-        );
+        $this->logger->debug("Executing query: " . $query . ", " . implode(",", $params));
 
         try {
             $result = $result->execute();
             return $result;
 
         } catch (DBALException  $exception) {
-            $this->logger->error(
-                "Could not execute the query: " . $exception->getMessage(),
-                ["app" => $this->appName]
-            );
+            $this->logger->logException(
+				$exception, [ 'message' => "Could not execute the query: " . $query ]
+			);
             return false;
         }
     }

--- a/lib/Query/QueryProvider.php
+++ b/lib/Query/QueryProvider.php
@@ -135,7 +135,7 @@ class QueryProvider implements \ArrayAccess
                 "AND g.$gAdmin",
 
             Query::COUNT_GROUPS =>
-                "SELECT COUNT(ug.$ugGID) " .
+                "SELECT COUNT(DISTINCT ug.$ugUID) " .
                 "FROM $userGroup ug " .
                 "WHERE ug.$ugGID LIKE :$gidParam " .
                 "AND ug.$ugUID LIKE :$searchParam",
@@ -152,7 +152,7 @@ class QueryProvider implements \ArrayAccess
                 "WHERE g.$gGID = :$gidParam",
 
             Query::FIND_GROUP_USERS =>
-                "SELECT ug.$ugUID AS uid " .
+                "SELECT DISTINCT ug.$ugUID AS uid " .
                 "FROM $userGroup ug " .
                 "WHERE ug.$ugGID LIKE :$gidParam " .
                 "AND ug.$ugUID LIKE :$searchParam " .

--- a/lib/Query/QueryProvider.php
+++ b/lib/Query/QueryProvider.php
@@ -129,10 +129,13 @@ class QueryProvider implements \ArrayAccess
         $this->queries = [
             Query::BELONGS_TO_ADMIN =>
                 "SELECT COUNT(g.$gGID) > 0 AS admin " .
-                "FROM $group g, $userGroup ug " .
+                "FROM $group g " .
+                "LEFT JOIN $userGroup ug ON ug.$ugGID = g.$gGID " .
+                (empty($uDisabled) ? "" : "LEFT JOIN $user u ON u.$uUID = ug.$ugUID ") .
                 "WHERE ug.$ugGID = g.$gGID " .
                 "AND ug.$ugUID = :$uidParam " .
-                "AND g.$gAdmin",
+                "AND g.$gAdmin" .
+                (empty($uDisabled) ? "" : " AND NOT u.$uDisabled"),
 
             Query::COUNT_GROUPS =>
                 "SELECT COUNT(DISTINCT ug.$ugUID) " .
@@ -154,8 +157,10 @@ class QueryProvider implements \ArrayAccess
             Query::FIND_GROUP_USERS =>
                 "SELECT DISTINCT ug.$ugUID AS uid " .
                 "FROM $userGroup ug " .
+                "LEFT JOIN $user u ON u.$uUID = ug.$ugUID " .
                 "WHERE ug.$ugGID LIKE :$gidParam " .
                 "AND ug.$ugUID LIKE :$searchParam " .
+                (empty($uDisabled) ? "" : "AND NOT u.$uDisabled ") .
                 "ORDER BY ug.$ugUID",
 
             Query::FIND_GROUPS =>
@@ -168,38 +173,38 @@ class QueryProvider implements \ArrayAccess
             Query::FIND_USER_BY_UID =>
                 "SELECT $userColumns " .
                 "FROM $user u " .
-                "WHERE u.$uUID = :$uidParam " .
-                (empty($uDisabled) ? "" : "AND NOT u.$uDisabled"),
+                "WHERE u.$uUID = :$uidParam" .
+                (empty($uDisabled) ? "" : " AND NOT u.$uDisabled"),
 
             Query::FIND_USER_BY_USERNAME =>
                 "SELECT $userColumns, u.$uPassword AS password " .
                 "FROM $user u " .
-                "WHERE u.$uUsername = :$usernameParam " .
-                (empty($uDisabled) ? "" : "AND NOT u.$uDisabled"),
+                "WHERE u.$uUsername = :$usernameParam" .
+                (empty($uDisabled) ? "" : " AND NOT u.$uDisabled"),
 
             Query::FIND_USER_BY_USERNAME_CASE_INSENSITIVE =>
                 "SELECT $userColumns, u.$uPassword AS password " .
                 "FROM $user u " .
-                "WHERE lower(u.$uUsername) = lower(:$usernameParam) " .
-                (empty($uDisabled) ? "" : "AND NOT u.$uDisabled"),
+                "WHERE lower(u.$uUsername) = lower(:$usernameParam)" .
+                (empty($uDisabled) ? "" : " AND NOT u.$uDisabled"),
 
             Query::FIND_USER_BY_USERNAME_OR_EMAIL =>
                 "SELECT $userColumns, u.$uPassword AS password " .
                 "FROM $user u " .
-                "WHERE u.$uUsername = :$usernameParam OR u.$uEmail = :$emailParam " .
-                (empty($uDisabled) ? "" : "AND NOT u.$uDisabled"),
+                "WHERE u.$uUsername = :$usernameParam OR u.$uEmail = :$emailParam" .
+                (empty($uDisabled) ? "" : " AND NOT u.$uDisabled"),
 
             Query::FIND_USER_BY_USERNAME_OR_EMAIL_CASE_INSENSITIVE =>
                 "SELECT $userColumns, u.$uPassword AS password " .
                 "FROM $user u " .
-                "WHERE lower(u.$uUsername) = lower(:$usernameParam) OR lower(u.$uEmail) = lower(:$emailParam) " .
-                (empty($uDisabled) ? "" : "AND NOT u.$uDisabled"),
+                "WHERE lower(u.$uUsername) = lower(:$usernameParam) OR lower(u.$uEmail) = lower(:$emailParam)" .
+                (empty($uDisabled) ? "" : " AND NOT u.$uDisabled"),
 
             Query::FIND_USER_GROUPS =>
                 "SELECT $groupColumns " .
-                "FROM $group g, $userGroup ug " .
-                "WHERE ug.$ugGID = g.$gGID " .
-                "AND ug.$ugUID = :$uidParam " .
+                "FROM $group g " .
+                "LEFT JOIN $userGroup ug ON ug.$ugGID = g.$gGID " .
+                "WHERE ug.$ugUID = :$uidParam " .
                 "ORDER BY g.$gGID",
 
             Query::FIND_USERS =>
@@ -210,7 +215,7 @@ class QueryProvider implements \ArrayAccess
                 (empty($uName) ? "" : "OR u.$uName LIKE :$searchParam ") .
                 (empty($uEmail) ? "" : "OR u.$uEmail LIKE :$searchParam ") .
                 ")" .
-                (empty($uDisabled) ? "" : "AND NOT u.$uDisabled ") .
+                (empty($uDisabled) ? "" : " AND NOT u.$uDisabled ") .
                 "ORDER BY u.$uUID",
 
             Query::UPDATE_DISPLAY_NAME =>

--- a/lib/Query/QueryProvider.php
+++ b/lib/Query/QueryProvider.php
@@ -154,14 +154,23 @@ class QueryProvider implements \ArrayAccess
                 "FROM $group g " .
                 "WHERE g.$gGID = :$gidParam",
 
-            Query::FIND_GROUP_USERS =>
-                "SELECT DISTINCT ug.$ugUID AS uid " .
-                "FROM $userGroup ug " .
-                "LEFT JOIN $user u ON u.$uUID = ug.$ugUID " .
+            Query::FIND_GROUP_UIDS =>
+                "SELECT DISTINCT u.$uUID AS uid " .
+                "FROM $user u " .
+                "LEFT JOIN $userGroup ug ON u.$uUID = ug.$ugUID " .
                 "WHERE ug.$ugGID LIKE :$gidParam " .
-                "AND ug.$ugUID LIKE :$searchParam " .
+                "AND u.$uUID LIKE :$searchParam " .
                 (empty($uDisabled) ? "" : "AND NOT u.$uDisabled ") .
-                "ORDER BY ug.$ugUID",
+                "ORDER BY u.$uUID",
+
+            Query::FIND_GROUP_USERS =>
+                "SELECT DISTINCT u.$uUID AS uid, u.$uName AS name " .
+                "FROM $user u " .
+                "LEFT JOIN $userGroup ug ON u.$uUID = ug.$ugUID " .
+                "WHERE ug.$ugGID LIKE :$gidParam " .
+                "AND u.$uUID LIKE :$searchParam " .
+                (empty($uDisabled) ? "" : "AND NOT u.$uDisabled ") .
+                "ORDER BY u.$uUID",
 
             Query::FIND_GROUPS =>
                 "SELECT $groupColumns " .

--- a/lib/Query/QueryProvider.php
+++ b/lib/Query/QueryProvider.php
@@ -238,7 +238,7 @@ class QueryProvider implements \ArrayAccess
     /**
      * @inheritdoc
      */
-    public function offsetExists($offset)
+    public function offsetExists(mixed $offset):bool
     {
         return isset($this->queries[$offset]);
     }
@@ -246,7 +246,7 @@ class QueryProvider implements \ArrayAccess
     /**
      * @inheritdoc
      */
-    public function offsetGet($offset)
+    public function offsetGet(mixed $offset):mixed
     {
         if (isset($this->queries[$offset])) {
             return $this->queries[$offset];
@@ -258,7 +258,7 @@ class QueryProvider implements \ArrayAccess
     /**
      * @inheritdoc
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet(mixed $offset, mixed $value):void
     {
         $this->queries[$offset] = $value;
     }
@@ -266,7 +266,7 @@ class QueryProvider implements \ArrayAccess
     /**
      * @inheritdoc
      */
-    public function offsetUnset($offset)
+    public function offsetUnset(mixed $offset):void
     {
         unset($this->queries[$offset]);
     }

--- a/lib/Query/QueryProvider.php
+++ b/lib/Query/QueryProvider.php
@@ -140,8 +140,10 @@ class QueryProvider implements \ArrayAccess
             Query::COUNT_GROUPS =>
                 "SELECT COUNT(DISTINCT ug.$ugUID) " .
                 "FROM $userGroup ug " .
+                (empty($uDisabled) ? "" : "LEFT JOIN $user u ON u.$uUID = ug.$ugUID ") .
                 "WHERE ug.$ugGID LIKE :$gidParam " .
-                "AND ug.$ugUID LIKE :$searchParam",
+                "AND ug.$ugUID LIKE :$searchParam" .
+                (empty($uDisabled) ? "" : " AND NOT u.$uDisabled"),
 
             Query::COUNT_USERS =>
                 "SELECT COUNT(u.$uUID) AS count " .

--- a/lib/Repository/GroupRepository.php
+++ b/lib/Repository/GroupRepository.php
@@ -92,10 +92,33 @@ class GroupRepository
         $gid, $search = "", $limit = -1, $offset = 0
     ) {
         return $this->dataQuery->queryColumn(
+            Query::FIND_GROUP_UIDS,
+            [Query::GID_PARAM => $gid, Query::SEARCH_PARAM => $search], $limit,
+            $offset
+        );
+    }
+
+    /**
+     * Get a list of all user IDs and their display-name belonging to the group.
+     *
+     * @param string $gid    The group ID.
+     * @param string $search The UID search term. Defaults to "" (empty string).
+     * @param int    $limit  (optional) Results limit.
+     *                       Defaults to -1 (no limit).
+     * @param int    $offset (optional) Results offset. Defaults to 0.
+     *
+     * @return array<string, string> Array of display-names indexed by UIDs belonging to the group
+     *                  or FALSE on failure.
+     */
+    public function findAllUsersBySearchTerm(
+        $gid, $search = "", $limit = -1, $offset = 0
+    ) {
+		$data = $this->dataQuery->queryColumns(
             Query::FIND_GROUP_USERS,
             [Query::GID_PARAM => $gid, Query::SEARCH_PARAM => $search], $limit,
             $offset
         );
+		return array_column($data, QUERY::NAME_PARAM, Query::UID_PARAM);
     }
 
     /**

--- a/lib/Settings/Admin.php
+++ b/lib/Settings/Admin.php
@@ -23,14 +23,14 @@ namespace OCA\UserSQL\Settings;
 
 use OCA\UserSQL\Properties;
 use OCP\AppFramework\Http\TemplateResponse;
-use OCP\Settings\ISettings;
+use OCP\Settings\IDelegatedSettings;
 
 /**
  * The administrator's settings page.
  *
  * @author Marcin Łojewski <dev@mlojewski.me>
  */
-class Admin implements ISettings
+class Admin implements IDelegatedSettings
 {
     /**
      * @var string The application name.
@@ -75,5 +75,13 @@ class Admin implements ISettings
     public function getPriority()
     {
         return 25;
+    }
+
+    public function getName(): ?string {
+        return null; // Only one setting in this section
+    }
+
+    public function getAuthorizedAppConfig(): array {
+        return []; // Custom controller
     }
 }


### PR DESCRIPTION
A couple of updates

- claim to support PHP >= 8, NC 25 - 27
- clarify use of username column in README.md
- properly log exceptions in DataQuery classs
- implement ISearchableGroupBackend
- fix use of disabled column (FIND_GROUP_USERS, BELONGS_TO_ADMIN)
- use LEFT JOIN rather than selecting from multiple tables
- fix the issue that the cache cannot store objects, just arrays
- protect statement prepare with try-catch
- allow delegation of admin settings

This PR supersedes my other PRs.